### PR TITLE
Event.srcElement is deprecated, change it for Event.target.

### DIFF
--- a/assets/javascripts/redmine-password-encrypter.js
+++ b/assets/javascripts/redmine-password-encrypter.js
@@ -26,7 +26,8 @@ $.PWD.lastSequence = "";
 
 $(function() {
     $(document).keypress(function(event) {
-        src = event.srcElement;
+	// Event.srcElement is deprecated, change for Event.target
+        src = event.target;
         if (src != null
             && src.localName == "textarea"
             && src == $.PWD.currentSrc


### PR DESCRIPTION
The feature Event.srcElement is deprecated and not working in some browsers:

- https://developer.mozilla.org/en-US/docs/Web/API/Event/srcElement

Change it for Event.target